### PR TITLE
fix type error

### DIFF
--- a/widgetry/static/widgetry/js/plugins/jquery.fkautocomplete.js
+++ b/widgetry/static/widgetry/js/plugins/jquery.fkautocomplete.js
@@ -122,12 +122,14 @@
 					$('#lookup_' + input_obj_name).val('');
 					$('#lookup_' + input_obj_name).flushCache();
 					var current_content_type_id = $('#' + content_type_obj_id).val();
-					if (config.add_urls[config.content_type_id].add_url) {
-						$('#add_id_' + input_obj_name).attr('href', config.add_urls[current_content_type_id].add_url);
-						$('#add_id_' + input_obj_name).show();
-					} else {
-						$('#add_id_' + input_obj_name).hide();
-					}
+					if (config.content_type_id) {
+    					if (config.add_urls[config.content_type_id].add_url) {
+    						$('#add_id_' + input_obj_name).attr('href', config.add_urls[current_content_type_id].add_url);
+    						$('#add_id_' + input_obj_name).show();
+    					} else {
+    						$('#add_id_' + input_obj_name).hide();
+    					}
+    				}	
 				});
 				if (config.content_type_id) {
 					$('#add_id_' + input_obj_name).attr('href', config.add_urls[config.content_type_id].add_url);


### PR DESCRIPTION
When selecting an object type from the `<select>`, there would be an error at line 125 of jquery.fkautocomplete.js:

```
TypeError: 'undefined' is not an object (evaluating
'config.add_urls[config.content_type_id].add_url')
```

This is because an unset `<select>` will give us an undefined `config.content_type_id`.

Solution: add `if (config.content_type_id) {` at line 125, so we don't bother (and we don't need) to do anything in that block until an object type has been selected. 
